### PR TITLE
Fix the way tags are declared

### DIFF
--- a/resources.tf
+++ b/resources.tf
@@ -7,8 +7,7 @@ resource "aws_vpc" "environment-example-two" {
   cidr_block = "10.0.0.0/16"
   enable_dns_hostnames = true
   enable_dns_support = true
-  tags {
+  tags = {
     Name = "terraform-aws-vpc-example-two"
   }
 }
-


### PR DESCRIPTION
The correct way to write this configuration is to use the equals sign, since tags is a map attribute rather than a nested configuration block:

  tags = {
    Name = "testTag"
  }

Newer TF versions will complain of:
Error: Unsupported block type

  on resources.tf line 10, in resource "aws_vpc" "environment-example-two":
  10:   tags {

Blocks of type "tags" are not expected here. Did you mean to define argument
"tags"? If so, use the equals sign to assign it a value.

REF:
https://github.com/hashicorp/terraform/issues/19325#issuecomment-437096913